### PR TITLE
Update DocuSign to add software token (#3050)

### DIFF
--- a/_data/legal.yml
+++ b/_data/legal.yml
@@ -13,6 +13,7 @@ websites:
       sms: Yes
       email: Yes
       phone: Yes
+      software: Yes
       doc: https://support.docusign.com/en/guides/ndse-user-guide-two-step-verification
 
     - name: HelloSign


### PR DESCRIPTION
Evidence is on the existing documentation link:
https://support.docusign.com/en/guides/ndse-user-guide-two-step-verification

Section:
"Use an Authenticator app for two-step verification"